### PR TITLE
exposed tol variable as naff() input, non-zero mean as warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ Authors:
 -  Panagiotis Zisopoulos (pzisopou .at. cern .dot. ch)
 
 A Python module that implements the `Numerical Analysis of Fundamental
-Frequencies method of J. Lashkar`_. The code works either as a script
-(as the original code of Lashkar) or loaded as a module in Python/Julia
+Frequencies method of J. Laskar`_. The code works either as a script
+(as the original code of Laskar) or loaded as a module in Python/Julia
 code or jupyter-like notebooks (i.e. SWAN).
 
 Example of Usage
@@ -33,4 +33,4 @@ Example of Usage
 
 – nkarast
 
-.. _Numerical Analysis of Fundamental Frequencies method of J. Lashkar: http://www.sciencedirect.com/science/article/pii/001910359090084M
+.. _Numerical Analysis of Fundamental Frequencies method of J. Laskar: http://www.sciencedirect.com/science/article/pii/001910359090084M

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ include_dirs = [np.get_include()]
 
 setup(
     name = "PyNAFF",
-    version = '1.1.4',
+    version = '1.1.5',
     description = 'A Python module that implements NAFF algorithm',
     long_description = long_description,
     # projects main page


### PR DESCRIPTION
Hi!
The tol variable can be set from the function to allow 'classic' behaviour (tol=1e-4), while it is still set as tol=1 as before by default.
Non-zero mean as warning can be muted (in some setting it can occur even with properly detrended data).
I hope this small change could also help others, if not, feel free to reject.
Cheers