### PR TITLE
Fix: ComplexWarning Moved

### DIFF
--- a/PyNAFF/PyNAFF.py
+++ b/PyNAFF/PyNAFF.py
@@ -1,7 +1,7 @@
 import numpy as np
 import math
 from warnings import warn, simplefilter
-simplefilter("ignore", np.ComplexWarning)  # suppress persisting cast to complex warnings from numpy
+simplefilter("ignore", np.exceptions.ComplexWarning)  # suppress persisting cast to complex warnings from numpy
 """
 # NAFF - Numerical Analysis of Fundamental Frequencies
 # Version : 1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy~=1.25.0
+numpy>=1.25.0
 setuptools~=65.5.1


### PR DESCRIPTION
Since NumPy 1.25+ and breaking in 2.0+, `ComplexWarning` moved into its own sub-namespace for `exceptions`.

Ref.:
- https://numpy.org/doc/1.25/reference/generated/numpy.exceptions.ComplexWarning.html
- https://numpy.org/doc/stable/reference/generated/numpy.exceptions.ComplexWarning.html

Fix #9